### PR TITLE
Remove redundant required gems

### DIFF
--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -1,7 +1,5 @@
-require 'openssl'
 require 'net/https'
 require 'time'
-require 'uri'
 
 ##
 # A Ruby implementation of the Duo API


### PR DESCRIPTION
# We... ARE THE **RUBY** GEMS! 
![lol](https://cloud.githubusercontent.com/assets/14850816/21082183/7a8942ae-bfa4-11e6-9a7d-bd78ef0a22c6.gif)

Anyway -- 

Right now duo_api_ruby requires the following 4 gems:

```ruby
require 'openssl'
require 'net/https'
require 'time'
require 'uri'
```

So, let's say we were to run that through pry/irb to see what that does:
![screen shot 1](https://cloud.githubusercontent.com/assets/14850816/21082038/ce100056-bfa0-11e6-8ab8-0859704ff10b.png)

We can see that uri is actually returning false, this is actually because it has already been required. I wrote a [whole blog post](https://medium.com/@KentGruber/redundant-ruby-gems-ad194048a73c) about this kind of thing -- and this [pull request](https://github.com/evilsocket/bettercap/pull/331) is very similar to one I made on bettercap addressing a similar issue.

So, I [used a tool](https://github.com/picatz/resquire) I recently made to help figure out the redundant gems in this project and attempted to benchmark the impact:

## Finding Redundant Gems with Resquire
![screen shot 3](https://cloud.githubusercontent.com/assets/14850816/21082087/c658c874-bfa1-11e6-93ea-96256a3a4101.png)

## Benchmarking the Impact
I found the optimized require statements to be roughly 1.2x faster than including the redundant requires.
![screen shot 2](https://cloud.githubusercontent.com/assets/14850816/21082072/759941b6-bfa1-11e6-9536-f0d366b637f2.png)

## Running Tests
After modifying the code and testing it with the tests provided with the gem, it looks like it doesn't seem to hinder the application in anyway. 
![screen shot 4](https://cloud.githubusercontent.com/assets/14850816/21082096/0b6083c6-bfa2-11e6-81d4-83c7c17ce016.png)

### Conclusion
So, we should be able to simply require two gems and have the exact same effect as having required all four gems ( which ends up requiring 3/4 anyway, and we only _need_ 2/4 of them ):
```ruby
require 'net/https'
require 'time'

# other ruby code for DuoAPI
```

### Testing Gem Behavior
 If you're worried about later readability or dependency worries later in the future ( since they're sort of _obscured_ by being required within another gem ), a test could be added to resemble something like this ( in rspec ) to describe that behavior:
```ruby
require "spec_helper"

describe DuoApi, "gem dependencies" do
  gems = [ 'openssl', 'net/https', 'time', 'uri' ]
  gems.each do |gem|
    it "should check #{gem} has been required" do
      expect(require gem).to eq(false)
    end
  end
end
```
We can then verify this check works -- even after removing the gems.
![screen shot 5](https://cloud.githubusercontent.com/assets/14850816/21082159/a7d6019e-bfa3-11e6-9d33-a0dac14b96bf.png)

So, we almost sacrifice a bit of "readability" ( of sorts? ), reduce redundancy, and -- in theory -- speed up the performance of the gem by removing two of the require statements.  

