### PR TITLE
fix TLS cert validation

### DIFF
--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'duo_api'
-  s.version     = '1.0.0'
+  s.version     = '1.0.1'
   s.summary     = 'Duo API Ruby'
   s.description = 'A Ruby implementation of the Duo API.'
   s.email       = 'support@duo.com'
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
     'lib/duo_api.rb',
     'ca_certs.pem'
   ]
-  s.add_development_dependency 'rake', '~> 0'
-  s.add_development_dependency 'rubocop', '~> 0'
-  s.add_development_dependency 'test-unit', '~> 0'
+  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rubocop', '~> 0.46.0'
+  s.add_development_dependency 'test-unit', '~> 3.2'
 end

--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -8,8 +8,9 @@ require 'uri'
 #
 class DuoApi
   @@encode_regex = Regexp.new('[^-_.~a-zA-Z\\d]')
+  attr_accessor :ca_file
 
-  def initialize(ikey, skey, host, proxy = nil)
+  def initialize(ikey, skey, host, proxy = nil, ca_file: nil)
     @ikey = ikey
     @skey = skey
     @host = host
@@ -24,6 +25,8 @@ class DuoApi
         proxy_uri.password
       ]
     end
+    @ca_file = ca_file ||
+               File.join(File.dirname(__FILE__), '..', 'ca_certs.pem')
   end
 
   def request(method, path, params = nil)
@@ -34,10 +37,8 @@ class DuoApi
     request.basic_auth(@ikey, signed)
     request['Date'] = current_date
 
-    ca_file = File.join(File.dirname(__FILE__), 'ca_certs.pem')
-
     Net::HTTP.start(uri.host, uri.port, *@proxy,
-                    use_ssl: true, ca_file: ca_file,
+                    use_ssl: true, ca_file: @ca_file,
                     verify_mode: OpenSSL::SSL::VERIFY_PEER) do |http|
       http.request(request)
     end

--- a/test/test_duo_api.rb
+++ b/test/test_duo_api.rb
@@ -13,6 +13,14 @@ class TestCase < Test::Unit::TestCase
 
 end
 
+class TestCertificateAuthority < TestCase
+
+  def test_default_ca_file_exists
+    assert_equal(true, File.exist?(@client.ca_file))
+  end
+
+end
+
 class TestQueryParameters < TestCase
 
   def assert_canon_params(params, expected)


### PR DESCRIPTION
@mschwager - Thank you so much for converting the ruby Duo library to a gem!

Unfortunately, the gemification in c1acc8266c2a63cbf1537c476c4a6d46a94b664a broke TLS cert validation. The issue is `duo_api.rb` changed directories, thus changing the relative location of the CA file. This PR...

* Uses the new relative path to the CA file
* Lets users override with a different CA file if desired. In the event Duo ever changes to a new CA without a root in the current bundle, the override gives users a workaround that doesn't require bumping the gem version.
* Sets working version numbers on the development gem dependencies
* Adds a unit test to make sure the client can find the CA file.

/cc @jameswhite