### PR TITLE
Revert "Fix default param typo"

### DIFF
--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -10,7 +10,7 @@ class DuoApi
   @@encode_regex = Regexp.new('[^-_.~a-zA-Z\\d]')
   attr_accessor :ca_file
 
-  def initialize(ikey, skey, host, proxy = nil, ca_file = nil)
+  def initialize(ikey, skey, host, proxy = nil, ca_file: nil)
     @ikey = ikey
     @skey = skey
     @host = host


### PR DESCRIPTION
Reverts duosecurity/duo_api_ruby#13

This isn't a type-o, it's a keyword declaration. If any clients called this method with the keyword param, this change will break them.