### PR TITLE
Address gemspec issue remove deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **Auth** - https://www.duosecurity.com/docs/authapi
 
-**Verify** - https://www.duosecurity.com/docs/duoverify
-
 **Admin** - https://www.duosecurity.com/docs/adminapi
 
 **Accounts** - https://www.duosecurity.com/docs/accountsapi

--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
     'ca_certs.pem'
   ]
   s.add_development_dependency 'rake', '~> 12.0'
-  s.add_development_dependency 'rubocop', '~> 0.46.0'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'test-unit', '~> 3.2'
 end


### PR DESCRIPTION
Updates the version of rubocop linter to 0.49.*

Removes reference to deprecated verify API