### PR TITLE
Add backoff and retry when a request is rate limited

### DIFF
--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'duo_api'
-  s.version     = '1.0.2'
+  s.version     = '1.1.0'
   s.summary     = 'Duo API Ruby'
   s.description = 'A Ruby implementation of the Duo API.'
   s.email       = 'support@duo.com'

--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'duo_api'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.summary     = 'Duo API Ruby'
   s.description = 'A Ruby implementation of the Duo API.'
   s.email       = 'support@duo.com'
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'test-unit', '~> 3.2'
+  s.add_development_dependency 'mocha', '~> 1.8.0'
 end

--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -10,6 +10,12 @@ class DuoApi
   @@encode_regex = Regexp.new('[^-_.~a-zA-Z\\d]')
   attr_accessor :ca_file
 
+  # Constants for handling rate limit backoff
+  MAX_BACKOFF_WAIT_SECS = 32
+  INITIAL_BACKOFF_WAIT_SECS = 1
+  BACKOFF_FACTOR = 2
+  RATE_LIMITED_RESP_CODE = '429'
+
   def initialize(ikey, skey, host, proxy = nil, ca_file: nil)
     @ikey = ikey
     @skey = skey
@@ -27,12 +33,6 @@ class DuoApi
     end
     @ca_file = ca_file ||
                File.join(File.dirname(__FILE__), '..', 'ca_certs.pem')
-
-    # Constants for handling rate limit backoff
-    @MAX_BACKOFF_WAIT_SECS = 32
-    @INITIAL_BACKOFF_WAIT_SECS = 1
-    @BACKOFF_FACTOR = 2
-    @RATE_LIMITED_RESP_CODE = '429'
   end
 
   def request(method, path, params = nil)
@@ -45,16 +45,16 @@ class DuoApi
 
     Net::HTTP.start(uri.host, uri.port, *@proxy,
                     use_ssl: true, ca_file: @ca_file,
-                    verify_mode: OpenSSL::SSL::VERIFY_PEER) do |http|
-      wait_secs = @INITIAL_BACKOFF_WAIT_SECS
+                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+      wait_secs = INITIAL_BACKOFF_WAIT_SECS
       while true do
         resp = http.request(request)
-        if resp.code != @RATE_LIMITED_RESP_CODE or wait_secs > @MAX_BACKOFF_WAIT_SECS
+        if resp.code != RATE_LIMITED_RESP_CODE or wait_secs > MAX_BACKOFF_WAIT_SECS
             return resp
         end
         random_offset = rand()
         sleep(wait_secs + random_offset)
-        wait_secs *= @BACKOFF_FACTOR
+        wait_secs *= BACKOFF_FACTOR
       end
     end
   end

--- a/test/test_duo_api.rb
+++ b/test/test_duo_api.rb
@@ -144,12 +144,10 @@ class TestSign < TestCase
 end
 
 class MockResponse < Object
+    attr_reader :code
+
     def initialize(code)
         @code = code
-    end
-
-    def code()
-        @code
     end
 end
 


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.

Add mocha as a dev dependency to enable mocking for tests