### PR TITLE
Specify user-agent string on http requests

### DIFF
--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -42,6 +42,7 @@ class DuoApi
     request = Net::HTTP.const_get(method.capitalize).new uri.to_s
     request.basic_auth(@ikey, signed)
     request['Date'] = current_date
+    request['User-Agent'] = 'duo_api_ruby/1.1.0'
 
     Net::HTTP.start(uri.host, uri.port, *@proxy,
                     use_ssl: true, ca_file: @ca_file,


### PR DESCRIPTION
Someone better at Ruby than me can tell me if there's a better way to get the version number.