### PR TITLE
Fix URI.encode deprecation warning on Ruby 2.7

### DIFF
--- a/lib/duo_api.rb
+++ b/lib/duo_api.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'openssl'
 require 'net/https'
 require 'time'
@@ -7,7 +8,6 @@ require 'uri'
 # A Ruby implementation of the Duo API
 #
 class DuoApi
-  @@encode_regex = Regexp.new('[^-_.~a-zA-Z\\d]')
   attr_accessor :ca_file
 
   # Constants for handling rate limit backoff
@@ -64,8 +64,8 @@ class DuoApi
 
   def encode_key_val(k, v)
     # encode the key and the value for a url
-    key = URI.encode(k.to_s, @@encode_regex)
-    value = URI.encode(v.to_s, @@encode_regex)
+    key = ERB::Util.url_encode(k.to_s)
+    value = ERB::Util.url_encode(v.to_s)
     key + '=' + value
   end
 


### PR DESCRIPTION
This resolves a deprecation warning that appears when running the gem using Ruby 2.7.

    .../lib/duo_api.rb:67: warning: URI.escape is obsolete

The solution is to simply use `ERB::Util.url_encode` instead (`URI.encode_www_form_component` also works if you try it locally, but this project's test suite prefers to encode spaces as `%20` instead of `+`).