### PR TITLE
Disable CI Schedule

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: '0 23 * * 1'      
 
 jobs:
   ruby-ci:


### PR DESCRIPTION
Scheduled workflows get disabled after a period of inactivity, which also means they don't run on pushes or CI, which is not great.