### PR TITLE
Fix CI and bring workflows up to date

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -10,8 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.2
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2.x
 

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.2.x
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1]
+        ruby-version: [2.7, 3.0, 3.1, 3.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: [2.7, 3.0, 3.1, 3.2]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 **Accounts** - https://www.duosecurity.com/docs/accountsapi
 
 ## Tested Against Ruby Versions:
-* 2.6
 * 2.7
+* 3.0
+* 3.1
+* 3.2
 
 # Installing
 


### PR DESCRIPTION
- Use latest version of checkout action (v3)
- Change ruby install action from deprecated actions/setup-ruby to ruby/setup-ruby
- Update testing matrix to all supported ruby versions
- Use latest ruby version for gem push workflow