### PR TITLE
Bring CI versions of Ruby and actions up to date

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7, 3.0, 3.1, 3.2]
+        ruby-version: [3.0, 3.1, 3.2]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 **Accounts** - https://www.duosecurity.com/docs/accountsapi
 
 ## Tested Against Ruby Versions:
-* 2.7
 * 3.0
 * 3.1
 * 3.2


### PR DESCRIPTION
## Description
Bring CI up to date with current versions of
- Ruby (2.7 is EoL per https://www.ruby-lang.org/en/downloads/branches/)
- Actions (checkout v4 is the current version)

## Motivation and Context
Just keeping on top of supported versions

## How Has This Been Tested?
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
