### PR TITLE
Fix version string in setup-ruby CI

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.x
+        ruby-version: 3.2
 
     - name: Publish to RubyGems
       run: |


### PR DESCRIPTION
## Description
The syntax for "latest 3.2 version" is wrong in the setup-ruby action

## Motivation and Context
(hopefully) fixes the publishing CI flow

## How Has This Been Tested?
Can't test this

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
