### PR TITLE
Relax base64 dependency version

### DIFF
--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'lib/duo_api/device.rb'
   ]
   s.required_ruby_version = '>= 2.5'
-  s.add_dependency 'base64', '~> 0.2.0'
+  s.add_dependency 'base64', '>= 0.2.0'
   s.add_development_dependency 'mocha', '~> 2.7.1'
   s.add_development_dependency 'ostruct', '~> 0.6.1'
   s.add_development_dependency 'rake', '~> 13.2.1'

--- a/duo_api.gemspec
+++ b/duo_api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'duo_api'
-  s.version     = '1.5.0'
+  s.version     = '1.5.1'
   s.summary     = 'Duo API Ruby'
   s.description = 'A Ruby implementation of the Duo API.'
   s.email       = 'support@duo.com'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the `base64` to require a minimum of `0.2.0` rather than only the `0.2.x` line. We needed to relax this in order to update to 1.5.0 for the CA bundle updates as our application has a dependency on `base64` version `0.3.0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->

Ran `bundle exec rake test` and ensured all tests were passing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
